### PR TITLE
Preserve mtime

### DIFF
--- a/lib/ExportDestination.php
+++ b/lib/ExportDestination.php
@@ -76,7 +76,9 @@ class ExportDestination implements IExportDestination {
 	 * {@inheritDoc}
 	 */
 	public function copyFolder(Folder $folder, string $destinationPath): bool {
-		$this->streamer->addEmptyDir($destinationPath);
+		$this->streamer->addEmptyDir($destinationPath, [
+			'timestamp' => $folder->getMTime(),
+		]);
 		$nodes = $folder->getDirectoryListing();
 		foreach ($nodes as $node) {
 			if ($node instanceof File) {
@@ -86,7 +88,9 @@ class ExportDestination implements IExportDestination {
 					continue;
 				}
 				$read = $node->fopen('rb');
-				$this->streamer->addFileFromStream($read, $destinationPath.'/'.$node->getName());
+				$this->streamer->addFileFromStream($read, $destinationPath.'/'.$node->getName(), [
+					'timestamp' => $node->getMTime(),
+				]);
 			} elseif ($node instanceof Folder) {
 				$success = $this->copyFolder($node, $destinationPath.'/'.$node->getName());
 				if ($success === false) {

--- a/lib/ImportSource.php
+++ b/lib/ImportSource.php
@@ -32,11 +32,10 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\UserMigration\IImportSource;
 use OCP\UserMigration\UserMigrationException;
-use OC\Archive\Archive;
 use OC\Archive\ZIP;
 
 class ImportSource implements IImportSource {
-	private Archive $archive;
+	private ZIP $archive;
 
 	private string $path;
 

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.21.0@d8bec4c7aaee111a532daec32fb09de5687053d1">
+<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+  <file src="lib/Controller/ApiController.php">
+    <UndefinedInterfaceMethod occurrences="4">
+      <code>getDescription</code>
+      <code>getDisplayName</code>
+      <code>getId</code>
+      <code>getId</code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="lib/ExportDestination.php">
     <InvalidArgument occurrences="3">
       <code>$read</code>
@@ -11,16 +19,19 @@
     </MethodSignatureMismatch>
   </file>
   <file src="lib/ImportSource.php">
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>new ZIP($this-&gt;path)</code>
-    </InvalidPropertyAssignmentValue>
+    <UndefinedMethod occurrences="1">
+      <code>getStat</code>
+    </UndefinedMethod>
   </file>
   <file src="lib/Service/UserMigrationService.php">
-    <MissingDependency occurrences="4">
-      <code>$this-&gt;root</code>
-      <code>$this-&gt;root</code>
-      <code>IRootFolder</code>
-      <code>IRootFolder</code>
-    </MissingDependency>
+    <InvalidArgument occurrences="1">
+      <code>$migratorVersions</code>
+    </InvalidArgument>
+    <UndefinedInterfaceMethod occurrences="4">
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+    </UndefinedInterfaceMethod>
   </file>
 </files>


### PR DESCRIPTION
Now storing mtime as mtime metadata in the Zip file.

The import procedure has been adjusted to use the "stat" information
from the ZIP file which is accessible in sequential form, so the
recursion was removed. This assumed that the ZIP entries are always
correctly ordered.

- [x] REQUIRES: https://github.com/nextcloud/server/pull/31929

For #83 