### PR TITLE
Avoid calling getPath on IExportDestination, it only makes sense with…

### DIFF
--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -82,12 +82,13 @@ class Export extends Command {
 			}
 			$folder = realpath($folder);
 			$exportDestination = new TempExportDestination($this->tempManager);
-			$path = $this->migrationService->export($exportDestination, $userObject, null, $output);
+			$this->migrationService->export($exportDestination, $userObject, null, $output);
+			$path = $exportDestination->getPath();
 			$exportName = $userObject->getUID().'_'.date('Y-m-d_H-i-s');
 			if (rename($path, $folder.'/'.$exportName.'.zip') === false) {
 				throw new \Exception("Failed to move $path to $folder/$exportName.zip");
 			}
-			$output->writeln("Moved the export to $folder/$exportName.zip");
+			$output->writeln("Export saved in $folder/$exportName.zip");
 		} catch (\Exception $e) {
 			$output->writeln("<error>" . $e->getMessage() . "</error>");
 			return $e->getCode() !== 0 ? (int)$e->getCode() : 1;

--- a/lib/Service/UserMigrationService.php
+++ b/lib/Service/UserMigrationService.php
@@ -76,9 +76,8 @@ class UserMigrationService {
 	/**
 	 * @param ?string[] $filteredMigratorList If not null, only these migrators will run. If empty only the main account data will be exported.
 	 * @throws UserMigrationException
-	 * @return string path of the export
 	 */
-	public function export(IExportDestination $exportDestination, IUser $user, ?array $filteredMigratorList = null, ?OutputInterface $output = null): string {
+	public function export(IExportDestination $exportDestination, IUser $user, ?array $filteredMigratorList = null, ?OutputInterface $output = null): void {
 		$output = $output ?? new NullOutput();
 		$uid = $user->getUID();
 
@@ -125,8 +124,6 @@ class UserMigrationService {
 		}
 
 		$exportDestination->close();
-		$output->writeln("Export saved in ".$exportDestination->getPath());
-		return $exportDestination->getPath();
 	}
 
 	public function import(string $path, ?IUser $user = null, ?OutputInterface $output = null): void {

--- a/lib/UserFolderExportDestination.php
+++ b/lib/UserFolderExportDestination.php
@@ -38,10 +38,10 @@ class UserFolderExportDestination extends ExportDestination {
 			$file = $userFolder->get($this->path);
 			if (!$file instanceof File) {
 				$file->delete();
-				$file = $userFolder->newFile($path);
+				$file = $userFolder->newFile($this->path);
 			}
 		} catch (NotFoundException $e) {
-			$file = $userFolder->newFile($path);
+			$file = $userFolder->newFile($this->path);
 		}
 		$r = $file->fopen('w');
 		parent::__construct($r);


### PR DESCRIPTION
… context

getPath exists on both TempExportDestination and
 UserFolderExportDestination but it does not have the same meaning in
 both cases.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>