### PR TITLE
Add selective data export to CLI

### DIFF
--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -133,8 +133,8 @@ class Export extends Command {
 					);
 					return 0;
 				default:
-					$io->warning("Invalid list argument: \"$list\"");
-					return 2;
+					$io->error("Invalid list argument: \"$list\"");
+					return 1;
 			}
 		}
 
@@ -148,8 +148,8 @@ class Export extends Command {
 				} else {
 					foreach ($types as $id) {
 						if (!in_array($id, array_map(fn (IMigrator $migrator) => $migrator->getId(), $migrators), true)) {
-							$io->warning("Invalid type: \"$id\"");
-							return 2;
+							$io->error("Invalid type: \"$id\"");
+							return 1;
 						}
 					}
 					$selectedMigrators = $types;
@@ -159,8 +159,8 @@ class Export extends Command {
 
 		$uid = $input->getArgument('user');
 		if (empty($uid)) {
-			$io->warning('Missing user argument');
-			return 2;
+			$io->error('Missing user argument');
+			return 1;
 		}
 
 		$user = $this->userManager->get($uid);
@@ -171,8 +171,8 @@ class Export extends Command {
 
 		$folder = $input->getArgument('folder');
 		if (empty($folder)) {
-			$io->warning('Missing folder argument');
-			return 2;
+			$io->error('Missing folder argument');
+			return 1;
 		}
 
 		try {

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -92,8 +92,17 @@ class Export extends Command {
 		/** @var WrappableOutputFormatterInterface $formatter */
 		$formatter = $io->getFormatter();
 
-		$args = array_filter($input->getArguments(), fn (?string $value, string $arg) => $arg === 'command' ? false : !empty($value), ARRAY_FILTER_USE_BOTH);
-		$options = array_filter($input->getOptions(), fn ($value) => $value !== false);
+		// Filter for only explicitly passed arguments
+		$args = array_filter(
+			$input->getArguments(),
+			fn (?string $value, string $arg) => $arg === 'command' ? false : !empty($value),
+			ARRAY_FILTER_USE_BOTH,
+		);
+		// Filter for only explicitly passed options
+		$options = array_filter(
+			$input->getOptions(),
+			fn ($value) => $value !== false,
+		);
 
 		// Show help if no arguments or options are passed
 		if (empty($args) && empty($options)) {

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -34,6 +34,7 @@ use OCP\IUserManager;
 use OCP\UserMigration\IMigrator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
+use Symfony\Component\Console\Formatter\WrappableOutputFormatterInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -88,6 +89,8 @@ class Export extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
+		/** @var WrappableOutputFormatterInterface $formatter */
+		$formatter = $io->getFormatter();
 
 		$args = array_filter($input->getArguments(), fn (?string $value, string $arg) => $arg === 'command' ? false : !empty($value), ARRAY_FILTER_USE_BOTH);
 		$options = array_filter($input->getOptions(), fn ($value) => $value !== false);
@@ -114,8 +117,7 @@ class Export extends Command {
 							fn (IMigrator $migrator) => [
 								$migrator->getDisplayName(),
 								$migrator->getId(),
-								// Wrap long descriptions
-								'<comment>' . implode("\n", mb_str_split($migrator->getDescription(), 80)) . '</comment>',
+								'<comment>' . $formatter->formatAndWrap($migrator->getDescription(), 80) . '</comment>',
 							],
 							$migrators,
 						)

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -139,6 +139,7 @@ class Export extends Command {
 			return 1;
 		}
 
+		$selectedMigrators = null;
 		$types = $input->getOption('types');
 		if ($types !== false) {
 			$types = explode(',', $types);
@@ -170,7 +171,7 @@ class Export extends Command {
 			}
 			$folder = realpath($folder);
 			$exportDestination = new TempExportDestination($this->tempManager);
-			$this->migrationService->export($exportDestination, $userObject, $selectedMigrators ?? null, $io);
+			$this->migrationService->export($exportDestination, $userObject, $selectedMigrators, $io);
 			$path = $exportDestination->getPath();
 			$exportName = $userObject->getUID().'_'.date('Y-m-d_H-i-s');
 			if (rename($path, $folder.'/'.$exportName.'.zip') === false) {

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -154,7 +154,7 @@ class Export extends Command {
 
 		$userObject = $this->userManager->get($user);
 		if (!$userObject instanceof IUser) {
-			$io->error("Unknown user <" . $input->getArgument('user') . ">");
+			$io->error("Unknown user <$user>");
 			return 1;
 		}
 

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -146,15 +146,15 @@ class Export extends Command {
 			}
 		}
 
-		$user = $input->getArgument('user');
-		if (empty($user)) {
+		$uid = $input->getArgument('user');
+		if (empty($uid)) {
 			$io->warning('Missing user argument');
 			return 2;
 		}
 
-		$userObject = $this->userManager->get($user);
-		if (!$userObject instanceof IUser) {
-			$io->error("Unknown user <$user>");
+		$user = $this->userManager->get($uid);
+		if (!$user instanceof IUser) {
+			$io->error("Unknown user <$uid>");
 			return 1;
 		}
 
@@ -171,9 +171,9 @@ class Export extends Command {
 			}
 			$folder = realpath($folder);
 			$exportDestination = new TempExportDestination($this->tempManager);
-			$this->migrationService->export($exportDestination, $userObject, $selectedMigrators, $io);
+			$this->migrationService->export($exportDestination, $user, $selectedMigrators, $io);
 			$path = $exportDestination->getPath();
-			$exportName = $userObject->getUID().'_'.date('Y-m-d_H-i-s');
+			$exportName = $user->getUID().'_'.date('Y-m-d_H-i-s');
 			if (rename($path, $folder.'/'.$exportName.'.zip') === false) {
 				throw new \Exception("Failed to move $path to $folder/$exportName.zip");
 			}

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2022 Côme Chilliet <come.chilliet@nextcloud.com>
  *
+ * @author Christopher Ng <chrng8@gmail.com>
  * @author Côme Chilliet <come.chilliet@nextcloud.com>
  *
  * @license AGPL-3.0
@@ -30,20 +31,25 @@ use OCA\UserMigration\TempExportDestination;
 use OCP\ITempManager;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\UserMigration\IMigrator;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class Export extends Command {
 	private IUserManager $userManager;
 	private UserMigrationService $migrationService;
 	private ITempManager $tempManager;
 
-	public function __construct(IUserManager $userManager,
-								UserMigrationService $migrationService,
-								ITempManager $tempManager
-								) {
+	public function __construct(
+		IUserManager $userManager,
+		UserMigrationService $migrationService,
+		ITempManager $tempManager
+	) {
 		parent::__construct();
 		$this->userManager = $userManager;
 		$this->migrationService = $migrationService;
@@ -54,43 +60,125 @@ class Export extends Command {
 		$this
 			->setName('user:export')
 			->setDescription('Export a user.')
+			->addOption(
+				'list',
+				'l',
+				InputOption::VALUE_OPTIONAL,
+				'List the available data types, pass <comment>--list=full</comment> to show more information',
+				false,
+			)
+			->addOption(
+				'types',
+				't',
+				InputOption::VALUE_REQUIRED,
+				'Comma-separated list of data type ids, pass <comment>--types=none</comment> to only export base user data',
+				false,
+			)
 			->addArgument(
 				'user',
-				InputArgument::REQUIRED,
-				'user to export'
+				InputArgument::OPTIONAL,
+				'user to export',
 			)
 			->addArgument(
 				'folder',
-				InputArgument::REQUIRED,
-				'local folder to export into'
+				InputArgument::OPTIONAL,
+				'local folder to export into',
 			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$userObject = $this->userManager->get($input->getArgument('user'));
+		$io = new SymfonyStyle($input, $output);
 
+		$args = array_filter($input->getArguments(), fn (?string $value, string $arg) => $arg === 'command' ? false : !empty($value), ARRAY_FILTER_USE_BOTH);
+		$options = array_filter($input->getOptions(), fn ($value) => $value !== false);
+
+		// Show help if no arguments or options are passed
+		if (empty($args) && empty($options)) {
+			$help = new HelpCommand();
+			$help->setCommand($this);
+			return $help->run($input, $io);
+		}
+
+		$migrators = $this->migrationService->getMigrators();
+
+		$list = $input->getOption('list');
+		if ($list !== false) {
+			switch (true) {
+				case $list === null:
+					$io->writeln(array_map(fn (IMigrator $migrator) => $migrator->getId(), $migrators));
+					return 0;
+				case $list === 'full':
+					$io->table(
+						['Name', 'Id', 'Description'],
+						array_map(
+							fn (IMigrator $migrator) => [
+								$migrator->getDisplayName(),
+								$migrator->getId(),
+								// Wrap long descriptions
+								'<comment>' . implode("\n", mb_str_split($migrator->getDescription(), 80)) . '</comment>',
+							],
+							$migrators,
+						)
+					);
+					return 0;
+				default:
+					$io->warning("Invalid list argument: \"$list\"");
+					return 2;
+			}
+		}
+
+		$user = $input->getArgument('user');
+		if (empty($user)) {
+			$io->error('Missing user argument');
+			return 2;
+		}
+
+		$userObject = $this->userManager->get($user);
 		if (!$userObject instanceof IUser) {
-			$output->writeln("<error>Unknown user " . $input->getArgument('user') . "</error>");
+			$io->error("Unknown user <" . $input->getArgument('user') . ">");
 			return 1;
 		}
 
+		$types = $input->getOption('types');
+		if ($types !== false) {
+			$types = explode(',', $types);
+			if ($types !== false) {
+				if (count($types) === 1 && reset($types) === 'none') {
+					$selectedMigrators = [];
+				} else {
+					foreach ($types as $id) {
+						if (!in_array($id, array_map(fn (IMigrator $migrator) => $migrator->getId(), $migrators), true)) {
+							$io->error("Invalid type: \"$id\"");
+							return 2;
+						}
+					}
+					$selectedMigrators = $types;
+				}
+			}
+		}
+
+		$folder = $input->getArgument('folder');
+		if (empty($folder)) {
+			$io->error('Missing folder argument');
+			return 2;
+		}
+
 		try {
-			$folder = $input->getArgument('folder');
 			if (!is_writable($folder)) {
-				$output->writeln("<error>The target folder must exist and be writable by the web server user</error>");
+				$io->error("The target folder must exist and be writable by the web server user");
 				return 2;
 			}
 			$folder = realpath($folder);
 			$exportDestination = new TempExportDestination($this->tempManager);
-			$this->migrationService->export($exportDestination, $userObject, null, $output);
+			$this->migrationService->export($exportDestination, $userObject, $selectedMigrators ?? null, $io);
 			$path = $exportDestination->getPath();
 			$exportName = $userObject->getUID().'_'.date('Y-m-d_H-i-s');
 			if (rename($path, $folder.'/'.$exportName.'.zip') === false) {
 				throw new \Exception("Failed to move $path to $folder/$exportName.zip");
 			}
-			$output->writeln("Export saved in $folder/$exportName.zip");
+			$io->writeln("Export saved in $folder/$exportName.zip");
 		} catch (\Exception $e) {
-			$output->writeln("<error>" . $e->getMessage() . "</error>");
+			$io->error($e->getMessage());
 			return $e->getCode() !== 0 ? (int)$e->getCode() : 1;
 		}
 

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -127,18 +127,6 @@ class Export extends Command {
 			}
 		}
 
-		$user = $input->getArgument('user');
-		if (empty($user)) {
-			$io->warning('Missing user argument');
-			return 2;
-		}
-
-		$userObject = $this->userManager->get($user);
-		if (!$userObject instanceof IUser) {
-			$io->error("Unknown user <" . $input->getArgument('user') . ">");
-			return 1;
-		}
-
 		$selectedMigrators = null;
 		$types = $input->getOption('types');
 		if ($types !== false) {
@@ -156,6 +144,18 @@ class Export extends Command {
 					$selectedMigrators = $types;
 				}
 			}
+		}
+
+		$user = $input->getArgument('user');
+		if (empty($user)) {
+			$io->warning('Missing user argument');
+			return 2;
+		}
+
+		$userObject = $this->userManager->get($user);
+		if (!$userObject instanceof IUser) {
+			$io->error("Unknown user <" . $input->getArgument('user') . ">");
+			return 1;
 		}
 
 		$folder = $input->getArgument('folder');

--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -129,7 +129,7 @@ class Export extends Command {
 
 		$user = $input->getArgument('user');
 		if (empty($user)) {
-			$io->error('Missing user argument');
+			$io->warning('Missing user argument');
 			return 2;
 		}
 
@@ -148,7 +148,7 @@ class Export extends Command {
 				} else {
 					foreach ($types as $id) {
 						if (!in_array($id, array_map(fn (IMigrator $migrator) => $migrator->getId(), $migrators), true)) {
-							$io->error("Invalid type: \"$id\"");
+							$io->warning("Invalid type: \"$id\"");
 							return 2;
 						}
 					}
@@ -159,14 +159,14 @@ class Export extends Command {
 
 		$folder = $input->getArgument('folder');
 		if (empty($folder)) {
-			$io->error('Missing folder argument');
+			$io->warning('Missing folder argument');
 			return 2;
 		}
 
 		try {
 			if (!is_writable($folder)) {
 				$io->error("The target folder must exist and be writable by the web server user");
-				return 2;
+				return 1;
 			}
 			$folder = realpath($folder);
 			$exportDestination = new TempExportDestination($this->tempManager);


### PR DESCRIPTION
Close https://github.com/nextcloud/user_migration/issues/94

```
Description:
  Export a user.

Usage:
  user:export [options] [--] [<user> [<folder>]]

Arguments:
  command               The command to execute
  user                  user to export
  folder                local folder to export into

Options:
  -l, --list[=LIST]     List the available data types, pass --list=full to show more information [default: false]
  -t, --types=TYPES     Comma-separated list of data type ids, pass --types=none to only export base user data [default: false]
  -h, --help            Display this help message
```