### PR TITLE
Add output flag for listing available data types

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -34,4 +34,9 @@
       <code>getId</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Command/Export.php">
+    <InvalidArgument occurrences="1">
+      <code>$this</code>
+    </InvalidArgument>
+  </file>
 </files>

--- a/tests/stubs/stub.phpstub
+++ b/tests/stubs/stub.phpstub
@@ -118,7 +118,6 @@ namespace OC\Hooks {
 }
 
 namespace OC\Cache {
-
 	use OCP\ICache;
 
 	class CappedMemoryCache implements ICache, \ArrayAccess {
@@ -134,5 +133,25 @@ namespace OC\Cache {
 		public function offsetUnset($offset): void {}
 		public function getData() {}
 		public static function isAvailable(): bool {}
+	}
+}
+
+namespace OC\Core\Command {
+	use Symfony\Component\Console\Input\InputInterface;
+	use Symfony\Component\Console\Output\OutputInterface;
+
+	class Base {
+		public const OUTPUT_FORMAT_PLAIN = 'plain';
+		public const OUTPUT_FORMAT_JSON = 'json';
+		public const OUTPUT_FORMAT_JSON_PRETTY = 'json_pretty';
+
+		protected string $defaultOutputFormat = static::OUTPUT_FORMAT_PLAIN;
+
+		public function __construct() {}
+		protected function configure() {}
+		public function run(InputInterface $input, OutputInterface $output) {}
+		public function setName(string $name) {}
+		public function getHelper(string $name) {}
+		protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, array $items, string $prefix = '  - ') {}
 	}
 }


### PR DESCRIPTION
Close https://github.com/nextcloud/user_migration/issues/170

#### `occ user:export --list`
```text
calendar
contacts
trashbin
account
files
```

#### `occ user:export --list --output=json`
```json
["calendar","contacts","trashbin","account","files"]
```

#### `occ user:export --list --output=json_pretty`
```json
[
    "calendar",
    "contacts",
    "trashbin",
    "account",
    "files"
]
```

#### `occ user:export --list=full`
```text
--------------------- ---------- ---------------------------------------------------------------------------------- 
  Name                  Id         Description                                                                       
 --------------------- ---------- ---------------------------------------------------------------------------------- 
  Calendar              calendar   Calendars including events, details and attendees                                 
  Contacts              contacts   Contacts and groups                                                               
  Deleted files         trashbin   Deleted files and folders in the trash bin (may expire during export if you are   
                                   low on storage space)                                                             
  Profile information   account    Profile picture, full name, email, phone number, address, website, Twitter, orga  
                                   nisation, role, headline, biography, and whether your profile is enabled          
  Files                 files      Files including versions, comments, collaborative tags, and favorites             
 --------------------- ---------- ---------------------------------------------------------------------------------- 
```

#### `occ user:export --list=full --output=json`
```json
{"calendar":{"name":"Calendar","description":"Calendars including events, details and attendees"},"contacts":{"name":"Contacts","description":"Contacts and groups"},"trashbin":{"name":"Deleted files","description":"Deleted files and folders in the trash bin (may expire during export if you are low on storage space)"},"account":{"name":"Profile information","description":"Profile picture, full name, email, phone number, address, website, Twitter, organisation, role, headline, biography, and whether your profile is enabled"},"files":{"name":"Files","description":"Files including versions, comments, collaborative tags, and favorites"}}
```

#### `occ user:export --list=full --output=json_pretty`
```json
{
    "calendar": {
        "name": "Calendar",
        "description": "Calendars including events, details and attendees"
    },
    "contacts": {
        "name": "Contacts",
        "description": "Contacts and groups"
    },
    "trashbin": {
        "name": "Deleted files",
        "description": "Deleted files and folders in the trash bin (may expire during export if you are low on storage space)"
    },
    "account": {
        "name": "Profile information",
        "description": "Profile picture, full name, email, phone number, address, website, Twitter, organisation, role, headline, biography, and whether your profile is enabled"
    },
    "files": {
        "name": "Files",
        "description": "Files including versions, comments, collaborative tags, and favorites"
    }
}
```