### PR TITLE
Fix error when checking exportability while a job is queued

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -191,7 +191,7 @@ class ApiController extends OCSController {
 	/**
 	 * @throws OCSException
 	 */
-	private function checkJobAndGetUser(): IUser {
+	private function checkJobAndGetUser($throwOnJobQueued = true): IUser {
 		$user = $this->userSession->getUser();
 
 		if (empty($user)) {
@@ -205,7 +205,9 @@ class ApiController extends OCSController {
 		}
 
 		if (!empty($job)) {
-			throw new OCSException('User migration operation already queued');
+			if ($throwOnJobQueued) {
+				throw new OCSException('User migration operation already queued');
+			}
 		}
 
 		return $user;
@@ -218,7 +220,7 @@ class ApiController extends OCSController {
 	 * @throws OCSException
 	 */
 	public function exportable(?array $migrators): DataResponse {
-		$user = $this->checkJobAndGetUser();
+		$user = $this->checkJobAndGetUser(false);
 
 		if (!is_null($migrators)) {
 			if (count($migrators) === 1 && reset($migrators) === '') {


### PR DESCRIPTION
Fix 

![image](https://user-images.githubusercontent.com/24800714/179859190-d9f42a58-0d0f-4b4d-90bd-7b0df6912502.png)

error message when checking exportability, i.e. reloading the page or changing migrator checkbox selection, while a job is queued