### PR TITLE
Ignore shares in FilesMigrator

### DIFF
--- a/lib/Db/UserExport.php
+++ b/lib/Db/UserExport.php
@@ -55,7 +55,8 @@ class UserExport extends Entity {
 	}
 
 	/**
-	 * Returns the migrators in an associative array
+	 * Returns the migrators in an array
+	 * @return ?string[]
 	 */
 	public function getMigratorsArray(): ?array {
 		return json_decode($this->migrators, true);
@@ -63,6 +64,7 @@ class UserExport extends Entity {
 
 	/**
 	 * Set the migrators
+	 * @param ?string[] $migrators
 	 */
 	public function setMigratorsArray(?array $migrators): void {
 		$this->setMigrators(json_encode($migrators));

--- a/lib/Db/UserImport.php
+++ b/lib/Db/UserImport.php
@@ -64,7 +64,8 @@ class UserImport extends Entity {
 	}
 
 	/**
-	 * Returns the migrators in an associative array
+	 * Returns the migrators in an array
+	 * @return ?string[]
 	 */
 	public function getMigratorsArray(): ?array {
 		return json_decode($this->migrators, true);
@@ -72,6 +73,7 @@ class UserImport extends Entity {
 
 	/**
 	 * Set the migrators
+	 * @param ?string[] $migrators
 	 */
 	public function setMigratorsArray(?array $migrators): void {
 		$this->setMigrators(json_encode($migrators));

--- a/lib/ExportDestination.php
+++ b/lib/ExportDestination.php
@@ -86,7 +86,7 @@ class ExportDestination implements IExportDestination {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function copyFolder(Folder $folder, string $destinationPath): void {
+	public function copyFolder(Folder $folder, string $destinationPath, ?callable $nodeFilter = null): void {
 		$success = $this->streamer->addEmptyDir($destinationPath, [
 			'timestamp' => $folder->getMTime(),
 		]);
@@ -95,6 +95,9 @@ class ExportDestination implements IExportDestination {
 		}
 		$nodes = $folder->getDirectoryListing();
 		foreach ($nodes as $node) {
+			if (($nodeFilter !== null) && !$nodeFilter($node)) {
+				continue;
+			}
 			if ($node instanceof File) {
 				if ($node->getName() === static::EXPORT_FILENAME) {
 					/* Skip previous user export file */

--- a/lib/ExportDestination.php
+++ b/lib/ExportDestination.php
@@ -112,7 +112,7 @@ class ExportDestination implements IExportDestination {
 					throw new UserMigrationException("Failed to copy file into ".$destinationPath.'/'.$node->getName()." in archive");
 				}
 			} elseif ($node instanceof Folder) {
-				$this->copyFolder($node, $destinationPath.'/'.$node->getName());
+				$this->copyFolder($node, $destinationPath.'/'.$node->getName(), $nodeFilter);
 			} else {
 				// ignore unknown node type, shouldn't happen
 				continue;

--- a/lib/Migrator/FilesMigrator.php
+++ b/lib/Migrator/FilesMigrator.php
@@ -381,6 +381,6 @@ class FilesMigrator implements IMigrator, ISizeEstimationMigrator {
 	 * {@inheritDoc}
 	 */
 	public function getDescription(): string {
-		return $this->l10n->t('Files including versions, comments, collaborative tags, and favorites (versions may expire during export if you are low on storage space)');
+		return $this->l10n->t('Files owned by you including versions, comments, collaborative tags, and favorites (versions may expire during export if you are low on storage space)');
 	}
 }

--- a/lib/Migrator/FilesMigrator.php
+++ b/lib/Migrator/FilesMigrator.php
@@ -35,6 +35,7 @@ use OCP\Comments\ICommentsManager;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\ITagManager;
@@ -139,9 +140,12 @@ class FilesMigrator implements IMigrator, ISizeEstimationMigrator {
 
 		$uid = $user->getUID();
 		$userFolder = $this->root->getUserFolder($uid);
+		$uidFilter = function (Node $node) use ($uid): bool {
+			return ($node->getOwner()->getUID() === $uid);
+		};
 
 		try {
-			$exportDestination->copyFolder($userFolder, static::PATH_FILES);
+			$exportDestination->copyFolder($userFolder, static::PATH_FILES, $uidFilter);
 		} catch (\Throwable $e) {
 			throw new UserMigrationException("Could not export files.", 0, $e);
 		}

--- a/lib/Migrator/FilesMigrator.php
+++ b/lib/Migrator/FilesMigrator.php
@@ -34,6 +34,7 @@ use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Files\File;
 use OCP\Files\Folder;
+use OCP\Files\IHomeStorage;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
@@ -94,11 +95,11 @@ class FilesMigrator implements IMigrator, ISizeEstimationMigrator {
 	public function getEstimatedExportSize(IUser $user): int {
 		$uid = $user->getUID();
 		$userFolder = $this->root->getUserFolder($uid);
-		$uidFilter = function (Node $node) use ($uid): bool {
-			return ($node->getOwner()->getUID() === $uid);
+		$nodeFilter = function (Node $node): bool {
+			return $node->getStorage()->instanceOfStorage(IHomeStorage::class);
 		};
 
-		$size = $this->estimateFolderSize($userFolder, $uidFilter) / 1024;
+		$size = $this->estimateFolderSize($userFolder, $nodeFilter) / 1024;
 
 		// Export file itself is not exported so we subtract it if existing
 		try {
@@ -161,12 +162,12 @@ class FilesMigrator implements IMigrator, ISizeEstimationMigrator {
 
 		$uid = $user->getUID();
 		$userFolder = $this->root->getUserFolder($uid);
-		$uidFilter = function (Node $node) use ($uid): bool {
-			return ($node->getOwner()->getUID() === $uid);
+		$nodeFilter = function (Node $node): bool {
+			return $node->getStorage()->instanceOfStorage(IHomeStorage::class);
 		};
 
 		try {
-			$exportDestination->copyFolder($userFolder, static::PATH_FILES, $uidFilter);
+			$exportDestination->copyFolder($userFolder, static::PATH_FILES, $nodeFilter);
 		} catch (\Throwable $e) {
 			throw new UserMigrationException("Could not export files.", 0, $e);
 		}


### PR DESCRIPTION
- [x] https://github.com/nextcloud/server/pull/34048

Files/folders which are not owned by the exported user are not exported anymore.
This should result in much more manageable export size.

- [x] Fix estimated export size
- [x] It excludes external mounts as well (through files_external)
- [x] Update documentation/UI

Fix https://github.com/nextcloud/user_migration/issues/203