### PR TITLE
Improve verbose output when an exception happens

### DIFF
--- a/lib/Command/Export.php
+++ b/lib/Command/Export.php
@@ -212,9 +212,10 @@ class Export extends Base {
 			$io->writeln("Export saved in $folder/$exportName.zip");
 		} catch (\Exception $e) {
 			if ($io->isDebug()) {
-				$io->error($e->getTraceAsString());
+				$io->error("$e");
+			} else {
+				$io->error($e->getMessage());
 			}
-			$io->error($e->getMessage());
 			return $e->getCode() !== 0 ? (int)$e->getCode() : 1;
 		}
 

--- a/lib/Command/Import.php
+++ b/lib/Command/Import.php
@@ -94,9 +94,10 @@ class Import extends Command {
 			$io->writeln("Successfully imported from ${path}");
 		} catch (\Exception $e) {
 			if ($io->isDebug()) {
-				$io->error($e->getTrace());
+				$io->error("$e");
+			} else {
+				$io->error($e->getMessage());
 			}
-			$io->error($e->getMessage());
 			return $e->getCode() !== 0 ? (int)$e->getCode() : 1;
 		}
 


### PR DESCRIPTION
Show the whole trace, not only the trace of the wrapper exception.

Follow-up of https://github.com/nextcloud/user_migration/pull/353