### PR TITLE
v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2023-05-17
+
+### Breaking
+
+* Drop support for Nextcloud 25 + 26
+
+### Changes
+
+* Nextcloud 27 compatibility
+* Improved 32bit compatibility https://github.com/nextcloud/user_migration/pull/408
+* CLI command exports directly to final folder instead of a temporary folder https://github.com/nextcloud/user_migration/pull/402
+* Various dependencies bump
+
 ## [4.0.0] - 2023-05-16
 
 * Nextcloud 27 compatibility

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ This app allows users to easily migrate from one instance to another using an ex
 - **⚙ Go into `Personal settings` > `Data migration` and start the import**
 - **🎉 Enjoy your stay on your new instance** and close you old account
 	]]></description>
-	<version>4.0.0</version>
+	<version>4.0.1</version>
 	<licence>agpl</licence>
 	<author>Côme Chilliet</author>
 	<author>Christopher Ng</author>
@@ -38,7 +38,7 @@ This app allows users to easily migrate from one instance to another using an ex
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_migration/main/screenshots/import.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="25" max-version="27"/>
+		<nextcloud min-version="27" max-version="27"/>
 	</dependencies>
 
 	<commands>


### PR DESCRIPTION
Officially drop Nextcloud 25 + 26 compatibility 🙈

### Release
- [ ] Merge this
- [ ] Pull the latest changes
	```bash
	git switch stable27
	git pull origin stable27
	```
- [ ] Create tag
	```bash
	git tag v4.0.1
	```
- [ ] Push the tag to https://github.com/nextcloud-releases/user_migration and https://github.com/nextcloud/user_migration
	```bash
	git remote add release git@github.com:nextcloud-releases/user_migration.git
	git push origin v4.0.1
	git push release v4.0.1
	```
- [ ] Create a release in https://github.com/nextcloud-releases/user_migration/releases and https://github.com/nextcloud/user_migration/releases with the changelist
- [ ] Check that the app release action ran successfully https://github.com/nextcloud-releases/user_migration/actions