### PR TITLE
Remove non-existing master branch from workflow

### DIFF
--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ["main", "master", "stable27", "stable26", "stable25"]
+        branches: ["main", "stable27", "stable26", "stable25"]
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 


### PR DESCRIPTION
Should fix the last failure in https://github.com/nextcloud/user_migration/actions/runs/5703843137