### PR TITLE
Remove deprecated ${var} syntax

### DIFF
--- a/lib/Command/Import.php
+++ b/lib/Command/Import.php
@@ -82,10 +82,10 @@ class Import extends Command {
 				$user = null;
 			}
 			$path = $input->getArgument('archive');
-			$io->writeln("Importing from ${path}…");
+			$io->writeln("Importing from {$path}…");
 			$importSource = new ImportSource($path);
 			$this->migrationService->import($importSource, $user, $io);
-			$io->writeln("Successfully imported from ${path}");
+			$io->writeln("Successfully imported from {$path}");
 		} catch (\Exception $e) {
 			if ($io->isDebug()) {
 				$io->error("$e");

--- a/lib/Service/UserMigrationService.php
+++ b/lib/Service/UserMigrationService.php
@@ -231,10 +231,8 @@ class UserMigrationService {
 		$output = $output ?? new NullOutput();
 
 		try {
-			$migratorVersions = $importSource->getMigratorVersions();
-
 			if (!$this->canImport($importSource)) {
-				throw new UserMigrationException("Version ${$migratorVersions[$this->getId()]} for main class ".static::class." is not compatible");
+				throw new UserMigrationException("Version ".($importSource->getMigratorVersion($this->getId()) ?? 'null')." for main class ".static::class." is not compatible");
 			}
 
 			// Check versions


### PR DESCRIPTION
This avoid deprecations warnings in the logs when importing through occ.