### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1231,16 +1231,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "488e4ad136853e5b24efa745e941c785cf41c51e"
+                "reference": "542baf3dd77072b542ba8621351f9e074d8f0f9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/488e4ad136853e5b24efa745e941c785cf41c51e",
-                "reference": "488e4ad136853e5b24efa745e941c785cf41c51e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/542baf3dd77072b542ba8621351f9e074d8f0f9a",
+                "reference": "542baf3dd77072b542ba8621351f9e074d8f0f9a",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0 || ~8.1 || ~8.2",
+                "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
@@ -1250,7 +1250,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "28.0.0-dev"
+                    "dev-master": "29.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1268,7 +1268,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-11-18T00:32:35+00:00"
+            "time": "2023-11-24T09:15:13+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency