### PR TITLE
fix: Fix fileid type in notification rich object

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -226,7 +226,7 @@ class Notifier implements INotifier {
 	private function fileToRichObject(File $file, string $path): array {
 		return [
 			'type' => 'file',
-			'id' => $file->getId(),
+			'id' => (string)$file->getId(),
 			'name' => $file->getName(),
 			'path' => $path,
 			'link' => $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $file->getId()]),


### PR DESCRIPTION
Fixes `Notification was claimed to be parsed, but was not fully parsed by OCA\\UserMigration\\Notification\\Notifier [app: user_migration, subject: exportDone]`.