### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -496,12 +496,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "97d7aa6e535670437a178084eea91a42998fef5c"
+                "reference": "b67645781728716a3ee4c32b2636b1dc4b30d894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/97d7aa6e535670437a178084eea91a42998fef5c",
-                "reference": "97d7aa6e535670437a178084eea91a42998fef5c",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b67645781728716a3ee4c32b2636b1dc4b30d894",
+                "reference": "b67645781728716a3ee4c32b2636b1dc4b30d894",
                 "shasum": ""
             },
             "require": {
@@ -537,7 +537,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-06-13T00:53:13+00:00"
+            "time": "2025-06-19T00:53:32+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency