### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -496,12 +496,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "64f0f74510b9c241b2aa930f9620eb8988d72c96"
+                "reference": "81254216713ed47a4a110e2544de275a4668d1ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/64f0f74510b9c241b2aa930f9620eb8988d72c96",
-                "reference": "64f0f74510b9c241b2aa930f9620eb8988d72c96",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/81254216713ed47a4a110e2544de275a4668d1ae",
+                "reference": "81254216713ed47a4a110e2544de275a4668d1ae",
                 "shasum": ""
             },
             "require": {
@@ -537,7 +537,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-10-17T00:49:00+00:00"
+            "time": "2025-10-24T00:45:44+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency