### PR TITLE
Cast key to string when retrieving value type

### DIFF
--- a/lib/Service/UserMigrationService.php
+++ b/lib/Service/UserMigrationService.php
@@ -330,7 +330,7 @@ class UserMigrationService {
 			foreach ($data as $app => $values) {
 				foreach ($values as $key => $value) {
 					try {
-						$type = $userConfig->getValueType($userId, $app, $key);
+						$type = $userConfig->getValueType($userId, $app, (string)$key);
 					} catch (UnknownKeyException) {
 						/** If type is unknown, default to mixed */
 						/** @psalm-suppress UndefinedClass ValueType only exists in 32 and higher, but in this if branch we know it exists */


### PR DESCRIPTION
This to prevent a typeerror.

"Argument #3 ($key) must be of type string, int given."

Signed-off-by: Yuri Van Hamme <yuko@gmx.li>