### PR TITLE
Fix deprecated InvalidArgumentException

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later.
  */
 
 namespace OCA\UserMigration\Notification;
@@ -23,228 +23,262 @@ use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\Notification\UnknownNotificationException;
 
-class Notifier implements INotifier {
-	protected IFactory $l10nFactory;
-	protected IURLGenerator $urlGenerator;
-	private IUserManager $userManager;
-	private IRootFolder $root;
+class Notifier implements INotifier
+{
+    protected IFactory $l10nFactory;
+    protected IURLGenerator $urlGenerator;
+    private IUserManager $userManager;
+    private IRootFolder $root;
 
-	public function __construct(IFactory $l10nFactory,
-		IURLGenerator $urlGenerator,
-		IUserManager $userManager,
-		IRootFolder $root) {
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
-		$this->userManager = $userManager;
-		$this->root = $root;
-	}
+    public function __construct(
+        IFactory $l10nFactory,
+        IURLGenerator $urlGenerator,
+        IUserManager $userManager,
+        IRootFolder $root
+    ) {
+        $this->l10nFactory = $l10nFactory;
+        $this->urlGenerator = $urlGenerator;
+        $this->userManager = $userManager;
+        $this->root = $root;
+    }
 
-	public function getID(): string {
-		return Application::APP_ID;
-	}
+    public function getID(): string
+    {
+        return Application::APP_ID;
+    }
 
-	public function getName(): string {
-		return $this->l10nFactory->get(Application::APP_ID)->t('User migration');
-	}
+    public function getName(): string
+    {
+        return $this->l10nFactory->get(Application::APP_ID)->t('User migration');
+    }
 
-	private function createNotificationException(string $message): \Exception {
-    	return class_exists(UnknownNotificationException::class)
-        	? new UnknownNotificationException($message)
-        	: new \InvalidArgumentException($message);
-	}
+    /**
+     * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+     */
+    public function prepare(INotification $notification, string $languageCode): INotification
+    {
+        if (Application::APP_ID !== $notification->getApp()) {
+            throw $this->createNotificationException('Unhandled app');
+        }
 
-	/**
-	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
-	 */
-	public function prepare(INotification $notification, string $languageCode): INotification {
-		if ($notification->getApp() !== Application::APP_ID) {
-			throw $this->createNotificationException('Unhandled app');
-		}
+        if ('exportDone' === $notification->getSubject()) {
+            return $this->handleExportDone($notification, $languageCode);
+        }
+        if ('exportFailed' === $notification->getSubject()) {
+            return $this->handleExportFailed($notification, $languageCode);
+        }
 
-		if ($notification->getSubject() === 'exportDone') {
-			return $this->handleExportDone($notification, $languageCode);
-		}
-		if ($notification->getSubject() === 'exportFailed') {
-			return $this->handleExportFailed($notification, $languageCode);
-		}
+        if ('importDone' === $notification->getSubject()) {
+            return $this->handleImportDone($notification, $languageCode);
+        }
+        if ('importFailed' === $notification->getSubject()) {
+            return $this->handleImportFailed($notification, $languageCode);
+        }
 
-		if ($notification->getSubject() === 'importDone') {
-			return $this->handleImportDone($notification, $languageCode);
-		}
-		if ($notification->getSubject() === 'importFailed') {
-			return $this->handleImportFailed($notification, $languageCode);
-		}
+        throw $this->createNotificationException('Unhandled subject');
+    }
 
-		throw $this->createNotificationException('Unhandled subject');
-	}
+    public function handleExportFailed(INotification $notification, string $languageCode): INotification
+    {
+        $l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
+        $param = $notification->getSubjectParameters();
 
-	public function handleExportFailed(INotification $notification, string $languageCode): INotification {
-		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
-		$param = $notification->getSubjectParameters();
+        $notification->setRichSubject($l->t('User export failed'))
+            ->setRichMessage(
+                $l->t('Your export of {user} failed.'),
+                [
+                    'user' => $this->getUserRichObject($l, $param['sourceUser']),
+                ]
+            )
+        ;
 
-		$notification->setRichSubject($l->t('User export failed'))
-			->setRichMessage(
-				$l->t('Your export of {user} failed.'),
-				[
-					'user' => $this->getUserRichObject($l, $param['sourceUser']),
-				]);
-		return $notification;
-	}
+        return $notification;
+    }
 
-	public function handleExportDone(INotification $notification, string $languageCode): INotification {
-		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
-		$param = $notification->getSubjectParameters();
+    public function handleExportDone(INotification $notification, string $languageCode): INotification
+    {
+        $l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
+        $param = $notification->getSubjectParameters();
 
-		$richObjects = [];
-		try {
-			$sourceUser = $this->getUser($param['sourceUser']);
-			$richObjects['user'] = $this->userToRichObject($sourceUser);
-		} catch (\InvalidArgumentException $e) {
-			$richObjects['user'] = $this->missingUserToRichObject($l, $param['sourceUser']);
-		}
-		if (isset($sourceUser)) {
-			try {
-				$exportFile = $this->getExportFile($sourceUser);
-				$path = rtrim($exportFile->getPath(), '/');
-				if (strpos($path, '/' . $notification->getUser() . '/files/') === 0) {
-					// Remove /user/files/...
-					$fullPath = $path;
-					[,,, $path] = explode('/', $fullPath, 4);
-				}
-				$richObjects['file'] = $this->fileToRichObject($exportFile, $path);
-			} catch (\InvalidArgumentException|NotFoundException $e) {
-				$richObjects['file'] = $this->missingFileToRichObject($l, ExportDestination::EXPORT_FILENAME);
-			}
-		} else {
-			$richObjects['file'] = $this->missingFileToRichObject($l, ExportDestination::EXPORT_FILENAME);
-		}
+        $richObjects = [];
 
-		$notification->setRichSubject($l->t('User export done'))
-			->setRichMessage(
-				$l->t('Your export of {user} has completed: {file}'),
-				$richObjects
-			);
+        try {
+            $sourceUser = $this->getUser($param['sourceUser']);
+            $richObjects['user'] = $this->userToRichObject($sourceUser);
+        } catch (\InvalidArgumentException $e) {
+            $richObjects['user'] = $this->missingUserToRichObject($l, $param['sourceUser']);
+        }
+        if (isset($sourceUser)) {
+            try {
+                $exportFile = $this->getExportFile($sourceUser);
+                $path = rtrim($exportFile->getPath(), '/');
+                if (0 === strpos($path, '/'.$notification->getUser().'/files/')) {
+                    // Remove /user/files/...
+                    $fullPath = $path;
+                    [,,, $path] = explode('/', $fullPath, 4);
+                }
+                $richObjects['file'] = $this->fileToRichObject($exportFile, $path);
+            } catch (\InvalidArgumentException|NotFoundException $e) {
+                $richObjects['file'] = $this->missingFileToRichObject($l, ExportDestination::EXPORT_FILENAME);
+            }
+        } else {
+            $richObjects['file'] = $this->missingFileToRichObject($l, ExportDestination::EXPORT_FILENAME);
+        }
 
-		return $notification;
-	}
+        $notification->setRichSubject($l->t('User export done'))
+            ->setRichMessage(
+                $l->t('Your export of {user} has completed: {file}'),
+                $richObjects
+            )
+        ;
 
-	public function handleImportFailed(INotification $notification, string $languageCode): INotification {
-		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
-		$param = $notification->getSubjectParameters();
+        return $notification;
+    }
 
-		$notification->setRichSubject($l->t('User import failed'))
-			->setRichMessage(
-				$l->t('Your import to {user} failed.'),
-				[
-					'user' => $this->getUserRichObject($l, $param['targetUser']),
-				]);
-		return $notification;
-	}
+    public function handleImportFailed(INotification $notification, string $languageCode): INotification
+    {
+        $l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
+        $param = $notification->getSubjectParameters();
 
-	public function handleImportDone(INotification $notification, string $languageCode): INotification {
-		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
-		$param = $notification->getSubjectParameters();
+        $notification->setRichSubject($l->t('User import failed'))
+            ->setRichMessage(
+                $l->t('Your import to {user} failed.'),
+                [
+                    'user' => $this->getUserRichObject($l, $param['targetUser']),
+                ]
+            )
+        ;
 
-		$path = $param['path'];
-		try {
-			$author = $this->getUser($param['author']);
-			$importFile = $this->getImportFile($author, $path);
-			$fileRichObject = $this->fileToRichObject($importFile, $path);
-		} catch (\InvalidArgumentException|NotFoundException $e) {
-			$fileRichObject = $this->missingFileToRichObject($l, $path);
-		}
+        return $notification;
+    }
 
-		$notification->setRichSubject($l->t('User import done'))
-			->setRichMessage(
-				$l->t('Your import of {file} into {user} has completed.'),
-				[
-					'user' => $this->getUserRichObject($l, $param['targetUser']),
-					'file' => $fileRichObject,
-				]);
+    public function handleImportDone(INotification $notification, string $languageCode): INotification
+    {
+        $l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
+        $param = $notification->getSubjectParameters();
 
-		return $notification;
-	}
+        $path = $param['path'];
 
-	/**
-	 * @throws \InvalidArgumentException
-	 */
-	protected function getUser(string $userId): IUser {
-		$user = $this->userManager->get($userId);
-		if ($user instanceof IUser) {
-			return $user;
-		}
-		throw new \InvalidArgumentException('User not found');
-	}
+        try {
+            $author = $this->getUser($param['author']);
+            $importFile = $this->getImportFile($author, $path);
+            $fileRichObject = $this->fileToRichObject($importFile, $path);
+        } catch (\InvalidArgumentException|NotFoundException $e) {
+            $fileRichObject = $this->missingFileToRichObject($l, $path);
+        }
 
-	/**
-	 * @throws \InvalidArgumentException
-	 * @throws NotFoundException
-	 */
-	protected function getExportFile(IUser $user): File {
-		$userFolder = $this->root->getUserFolder($user->getUID());
-		$file = $userFolder->get(ExportDestination::EXPORT_FILENAME);
-		if (!$file instanceof File) {
-			throw new \InvalidArgumentException('User export is not a file');
-		}
-		return $file;
-	}
+        $notification->setRichSubject($l->t('User import done'))
+            ->setRichMessage(
+                $l->t('Your import of {file} into {user} has completed.'),
+                [
+                    'user' => $this->getUserRichObject($l, $param['targetUser']),
+                    'file' => $fileRichObject,
+                ]
+            )
+        ;
 
-	/**
-	 * @throws \InvalidArgumentException
-	 * @throws NotFoundException
-	 */
-	protected function getImportFile(IUser $user, string $path): File {
-		$userFolder = $this->root->getUserFolder($user->getUID());
-		$file = $userFolder->get($path);
-		if (!$file instanceof File) {
-			throw new \InvalidArgumentException("Import file \"$path\" is not a file");
-		}
-		return $file;
-	}
+        return $notification;
+    }
 
-	/**
-	 * @return array{type: 'user'}
-	 */
-	protected function getUserRichObject(IL10N $l, string $userId): array {
-		try {
-			$user = $this->getUser($userId);
-			return $this->userToRichObject($user);
-		} catch (\InvalidArgumentException $e) {
-			return $this->missingUserToRichObject($l, $userId);
-		}
-	}
+    /**
+     * @throws \InvalidArgumentException
+     */
+    protected function getUser(string $userId): IUser
+    {
+        $user = $this->userManager->get($userId);
+        if ($user instanceof IUser) {
+            return $user;
+        }
 
-	private function userToRichObject(IUser $user): array {
-		return [
-			'type' => 'user',
-			'id' => $user->getUID(),
-			'name' => $user->getDisplayName(),
-		];
-	}
+        throw new \InvalidArgumentException('User not found');
+    }
 
-	private function missingUserToRichObject(IL10N $l, string $userId): array {
-		return [
-			'type' => 'user',
-			'id' => $userId,
-			'name' => $l->t('%s (missing)', [$userId]),
-		];
-	}
+    /**
+     * @throws \InvalidArgumentException
+     * @throws NotFoundException
+     */
+    protected function getExportFile(IUser $user): File
+    {
+        $userFolder = $this->root->getUserFolder($user->getUID());
+        $file = $userFolder->get(ExportDestination::EXPORT_FILENAME);
+        if (!$file instanceof File) {
+            throw new \InvalidArgumentException('User export is not a file');
+        }
 
-	private function fileToRichObject(File $file, string $path): array {
-		return [
-			'type' => 'file',
-			'id' => (string)$file->getId(),
-			'name' => $file->getName(),
-			'path' => $path,
-			'link' => $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $file->getId()]),
-		];
-	}
+        return $file;
+    }
 
-	private function missingFileToRichObject(IL10N $l, string $path): array {
-		return [
-			'type' => 'highlight',
-			'id' => basename($path),
-			'name' => $l->t('%s (missing)', [$path]),
-		];
-	}
+    /**
+     * @throws \InvalidArgumentException
+     * @throws NotFoundException
+     */
+    protected function getImportFile(IUser $user, string $path): File
+    {
+        $userFolder = $this->root->getUserFolder($user->getUID());
+        $file = $userFolder->get($path);
+        if (!$file instanceof File) {
+            throw new \InvalidArgumentException("Import file \"{$path}\" is not a file");
+        }
+
+        return $file;
+    }
+
+    /**
+     * @return array{type: 'user'}
+     */
+    protected function getUserRichObject(IL10N $l, string $userId): array
+    {
+        try {
+            $user = $this->getUser($userId);
+
+            return $this->userToRichObject($user);
+        } catch (\InvalidArgumentException $e) {
+            return $this->missingUserToRichObject($l, $userId);
+        }
+    }
+
+    private function createNotificationException(string $message): \Exception
+    {
+        return class_exists(UnknownNotificationException::class)
+        ? new UnknownNotificationException($message)
+        : new \InvalidArgumentException($message);
+    }
+
+    private function userToRichObject(IUser $user): array
+    {
+        return [
+            'type' => 'user',
+            'id' => $user->getUID(),
+            'name' => $user->getDisplayName(),
+        ];
+    }
+
+    private function missingUserToRichObject(IL10N $l, string $userId): array
+    {
+        return [
+            'type' => 'user',
+            'id' => $userId,
+            'name' => $l->t('%s (missing)', [$userId]),
+        ];
+    }
+
+    private function fileToRichObject(File $file, string $path): array
+    {
+        return [
+            'type' => 'file',
+            'id' => (string) $file->getId(),
+            'name' => $file->getName(),
+            'path' => $path,
+            'link' => $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $file->getId()]),
+        ];
+    }
+
+    private function missingFileToRichObject(IL10N $l, string $path): array
+    {
+        return [
+            'type' => 'highlight',
+            'id' => basename($path),
+            'name' => $l->t('%s (missing)', [$path]),
+        ];
+    }
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -47,12 +47,18 @@ class Notifier implements INotifier {
 		return $this->l10nFactory->get(Application::APP_ID)->t('User migration');
 	}
 
+	private function createNotificationException(string $message): \Exception {
+    	return class_exists(UnknownNotificationException::class)
+        	? new UnknownNotificationException($message)
+        	: new \InvalidArgumentException($message);
+	}
+
 	/**
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
-			throw new UnknownNotificationException('Unhandled app');
+			throw $this->createNotificationException('Unhandled app');
 		}
 
 		if ($notification->getSubject() === 'exportDone') {
@@ -69,7 +75,7 @@ class Notifier implements INotifier {
 			return $this->handleImportFailed($notification, $languageCode);
 		}
 
-		throw new UnknownNotificationException('Unhandled subject');
+		throw $this->createNotificationException('Unhandled subject');
 	}
 
 	public function handleExportFailed(INotification $notification, string $languageCode): INotification {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -21,6 +21,7 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	protected IFactory $l10nFactory;
@@ -51,7 +52,7 @@ class Notifier implements INotifier {
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
-			throw new \InvalidArgumentException('Unhandled app');
+			throw new UnknownNotificationException('Unhandled app');
 		}
 
 		if ($notification->getSubject() === 'exportDone') {
@@ -68,7 +69,7 @@ class Notifier implements INotifier {
 			return $this->handleImportFailed($notification, $languageCode);
 		}
 
-		throw new \InvalidArgumentException('Unhandled subject');
+		throw new UnknownNotificationException('Unhandled subject');
 	}
 
 	public function handleExportFailed(INotification $notification, string $languageCode): INotification {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -190,7 +190,7 @@ class Notifier implements INotifier
             return $user;
         }
 
-        throw new \InvalidArgumentException('User not found');
+        throw $this->createNotificationException('User not found');
     }
 
     /**
@@ -202,7 +202,7 @@ class Notifier implements INotifier
         $userFolder = $this->root->getUserFolder($user->getUID());
         $file = $userFolder->get(ExportDestination::EXPORT_FILENAME);
         if (!$file instanceof File) {
-            throw new \InvalidArgumentException('User export is not a file');
+            throw $this->createNotificationException('User export is not a file');
         }
 
         return $file;
@@ -217,7 +217,7 @@ class Notifier implements INotifier
         $userFolder = $this->root->getUserFolder($user->getUID());
         $file = $userFolder->get($path);
         if (!$file instanceof File) {
-            throw new \InvalidArgumentException("Import file \"{$path}\" is not a file");
+            throw $this->createNotificationException("Import file \"{$path}\" is not a file");
         }
 
         return $file;


### PR DESCRIPTION
Fix deprecated InvalidArgumentException in Notifier::prepare() to match Nextcloud 34 requirement, removing repeated log warning such as:
`Warning: OCA\UserMigration\Notification\Notifier::prepare() through \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself.`

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
